### PR TITLE
Add house system support

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,15 @@ import swisseph as swe
 import datetime
 
 
+def compute_chart_points(jd, lat, lon, hsys=b'P'):
+    """Return Ascendant, Midheaven and house cusps."""
+    cusps, ascmc = swe.houses(jd, lat, lon, hsys)
+    return {
+        'asc': ascmc[0],
+        'mc': ascmc[1],
+        'cusps': list(cusps),
+    }
+
 def compute_positions(jd):
     """Return ecliptic longitudes of major bodies for given Julian day."""
     planets = {
@@ -34,6 +43,7 @@ def index():
         tz_offset = float(request.form['tz_offset'])
         lat = float(request.form['latitude'])
         lon = float(request.form['longitude'])
+        hsys = request.form.get('house_system', 'P').encode()
 
         dt = datetime.datetime.strptime(f"{date_str} {time_str}", "%Y-%m-%d %H:%M")
         dt_utc = dt - datetime.timedelta(hours=tz_offset)
@@ -45,8 +55,13 @@ def index():
         )
 
         positions = compute_positions(jd)
+        chart_points = compute_chart_points(jd, lat, lon, hsys)
         return render_template('chart.html', positions=positions,
-                               lat=lat, lon=lon, dt=dt, dt_utc=dt_utc)
+                               lat=lat, lon=lon, dt=dt, dt_utc=dt_utc,
+                               asc=chart_points['asc'],
+                               mc=chart_points['mc'],
+                               cusps=chart_points['cusps'],
+                               house_system=hsys.decode())
     return render_template('index.html')
 
 if __name__ == '__main__':

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -14,6 +14,17 @@
     <tr><td>{{ name }}</td><td>{{ '%.2f'|format(position) }}</td></tr>
     {% endfor %}
   </table>
+  <h2>Chart Points</h2>
+  <p>Ascendant: {{ '%.2f'|format(asc) }}</p>
+  <p>Midheaven: {{ '%.2f'|format(mc) }}</p>
+
+  <h2>House Cusps ({{ house_system }})</h2>
+  <table border="1">
+    <tr><th>House</th><th>Cusp Longitude (deg)</th></tr>
+    {% for cusp in cusps %}
+    <tr><td>{{ loop.index }}</td><td>{{ '%.2f'|format(cusp) }}</td></tr>
+    {% endfor %}
+  </table>
   <a href="{{ url_for('index') }}">Back</a>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,11 @@
     <input type="number" name="latitude" step="any" required><br>
     <label>Longitude:</label>
     <input type="number" name="longitude" step="any" required><br>
+    <label>House system:</label>
+    <select name="house_system">
+      <option value="P">Placidus</option>
+      <option value="W">Whole Sign</option>
+    </select><br>
     <button type="submit">Generate</button>
   </form>
 </body>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import swisseph as swe
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from app import app, compute_positions
+from app import app, compute_positions, compute_chart_points
 
 
 def test_index_get():
@@ -11,6 +11,7 @@ def test_index_get():
     resp = client.get('/')
     assert resp.status_code == 200
     assert b'Generate your natal chart' in resp.data
+    assert b'House system' in resp.data
 
 
 def test_index_post_positions():
@@ -21,6 +22,7 @@ def test_index_post_positions():
         'tz_offset': '0',
         'latitude': '0',
         'longitude': '0',
+        'house_system': 'P'
     }
     resp = client.post('/', data=data)
     assert resp.status_code == 200
@@ -31,3 +33,16 @@ def test_index_post_positions():
     moon_lon = f"{expected['Moon']:.2f}".encode()
     assert sun_lon in resp.data
     assert moon_lon in resp.data
+    chart_points = compute_chart_points(jd, 0, 0, b'P')
+    asc_lon = f"{chart_points['asc']:.2f}".encode()
+    cusp1 = f"{chart_points['cusps'][0]:.2f}".encode()
+    assert asc_lon in resp.data
+    assert cusp1 in resp.data
+
+    # Check whole sign houses differ
+    data['house_system'] = 'W'
+    resp2 = client.post('/', data=data)
+    assert resp2.status_code == 200
+    chart_points_w = compute_chart_points(jd, 0, 0, b'W')
+    cusp1_w = f"{chart_points_w['cusps'][0]:.2f}".encode()
+    assert cusp1_w in resp2.data


### PR DESCRIPTION
## Summary
- compute ascendant, midheaven and house cusps
- allow selecting a house system on the form
- show chart points and house cusps in results
- test house system selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f3afd2f8832ea9b41bdf28b7b3e3