### PR TITLE
Add planetary retrograde status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Moon and Sun Natal Chart
 
 This project is a simple Flask web application that generates planetary positions for a natal chart using the [Swiss Ephemeris](https://www.astro.com/swisseph/).
-The application now also calculates major aspects between planets with their orb strength and identifies the chart ruler based on the ascendant sign.
+The application now also calculates major aspects between planets with their orb strength, identifies the chart ruler based on the ascendant sign, draws a chart wheel illustrating the houses and planetary locations, and indicates when planets are retrograde.
 
 ## Setup
 
@@ -14,6 +14,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 pip install -r requirements-dev.txt  # for running tests
 ```
+The `requirements.txt` file now includes `matplotlib` which is used to draw the chart wheel.
 
 ## Running
 

--- a/app.py
+++ b/app.py
@@ -4,6 +4,10 @@ import datetime
 import requests
 from timezonefinder import TimezoneFinder
 from zoneinfo import ZoneInfo
+import io
+import base64
+import math
+import matplotlib.pyplot as plt
 
 ZODIAC_SIGNS = [
     'Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo',
@@ -104,6 +108,28 @@ def compute_positions(jd):
     return positions
 
 
+def compute_retrogrades(jd):
+    """Return mapping of body name to boolean retrograde flag."""
+    planets = {
+        'Sun': swe.SUN,
+        'Moon': swe.MOON,
+        'Mercury': swe.MERCURY,
+        'Venus': swe.VENUS,
+        'Mars': swe.MARS,
+        'Jupiter': swe.JUPITER,
+        'Saturn': swe.SATURN,
+        'Uranus': swe.URANUS,
+        'Neptune': swe.NEPTUNE,
+        'Pluto': swe.PLUTO,
+        'Mean Node': swe.MEAN_NODE,
+    }
+    retrogrades = {}
+    for name, body in planets.items():
+        lon_lat_dist = swe.calc_ut(jd, body)[0]
+        retrogrades[name] = lon_lat_dist[3] < 0
+    return retrogrades
+
+
 def angular_distance(lon1, lon2):
     """Return smallest angular distance between two longitudes."""
     diff = abs(lon1 - lon2) % 360
@@ -133,6 +159,32 @@ def compute_aspects(positions):
                         'strength': strength,
                     })
     return aspects
+
+
+def draw_chart_wheel(positions, cusps):
+    """Return base64-encoded PNG of a simple chart wheel."""
+    fig, ax = plt.subplots(figsize=(6, 6), subplot_kw={'projection': 'polar'})
+    ax.set_theta_direction(-1)
+    ax.set_theta_offset(math.radians(90))
+    ax.set_yticklabels([])
+    ax.set_xticklabels([])
+
+    # draw house cusps
+    for cusp in cusps:
+        theta = math.radians(90 - cusp)
+        ax.plot([theta, theta], [0, 1], color='black', linewidth=0.5)
+
+    # plot planet positions
+    for name, lon in positions.items():
+        theta = math.radians(90 - lon)
+        ax.plot(theta, 0.8, 'o')
+        ax.text(theta, 0.85, name[0], ha='center', va='center', fontsize=8)
+
+    buf = io.BytesIO()
+    fig.tight_layout()
+    plt.savefig(buf, format='png')
+    plt.close(fig)
+    return base64.b64encode(buf.getvalue()).decode()
 
 
 def chart_ruler(asc_longitude):
@@ -197,10 +249,12 @@ def index():
             )
 
             positions = compute_positions(jd)
+            retrogrades = compute_retrogrades(jd)
             chart_points = compute_chart_points(jd, lat, lon, hsys)
             houses = compute_house_positions(positions, chart_points['cusps'])
             aspects = compute_aspects(positions)
             ruler = chart_ruler(chart_points['asc'])
+            chart_img = draw_chart_wheel(positions, chart_points['cusps'])
             formatted_positions = {n: format_longitude(p) for n, p in positions.items()}
             formatted_asc = format_longitude(chart_points['asc'])
             formatted_mc = format_longitude(chart_points['mc'])
@@ -211,6 +265,8 @@ def index():
                 houses=houses,
                 aspects=aspects,
                 chart_ruler=ruler,
+                chart_img=chart_img,
+                retrogrades=retrogrades,
                 lat=lat,
                 lon=lon,
                 dt=dt,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 pyswisseph
 requests
 timezonefinder
+matplotlib

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -6,15 +6,17 @@
 </head>
 <body>
   <h1>Natal Chart</h1>
+  <img src="data:image/png;base64,{{ chart_img }}" alt="Chart Wheel">
   <p>Birth time (local): {{ dt }}</p>
   <p>Converted to UTC: {{ dt_utc }}</p>
   <p>Coordinates: {{ lat }}, {{ lon }}</p>
   <table border="1">
-    <tr><th>Body</th><th>Position</th><th>House</th></tr>
+    <tr><th>Body</th><th>Position</th><th>R</th><th>House</th></tr>
     {% for name, position in positions.items() %}
     <tr>
       <td>{{ name }}</td>
       <td>{{ position }}</td>
+      <td>{% if retrogrades[name] %}R{% endif %}</td>
       <td>{{ houses[name] }}</td>
     </tr>
     {% endfor %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,6 +11,7 @@ from app import (
     compute_house_positions,
     compute_aspects,
     chart_ruler,
+    compute_retrogrades,
 )
 
 
@@ -36,6 +37,7 @@ def test_index_post_positions():
     assert resp.status_code == 200
     jd = swe.julday(2000, 1, 1, 12.0)
     expected = compute_positions(jd)
+    retro = compute_retrogrades(jd)
     chart_points = compute_chart_points(jd, 0, 0, b'P')
     houses = compute_house_positions(expected, chart_points['cusps'])
     # check formatted body positions and house numbers appear
@@ -58,6 +60,12 @@ def test_index_post_positions():
     chart_points_w = compute_chart_points(jd, 0, 0, b'W')
     cusp1_w = format_longitude(chart_points_w['cusps'][0]).replace("'", "&#39;").encode()
     assert cusp1_w in resp2.data
+    assert b'data:image/png;base64' in resp.data
+    assert b'Saturn' in resp.data
+    import re
+    assert re.search(b'Saturn.*?R</td>', resp.data, re.S)
+    assert retro['Saturn'] is True
+    assert retro['Sun'] is False
 
 
 def test_aspects_and_chart_ruler():
@@ -70,3 +78,6 @@ def test_aspects_and_chart_ruler():
     )
     chart_points = compute_chart_points(jd, 0, 0, b'P')
     assert chart_ruler(chart_points['asc']) == 'Mars'
+    retro = compute_retrogrades(jd)
+    assert retro['Saturn'] is True
+


### PR DESCRIPTION
## Summary
- compute retrograde motion for chart bodies
- show an "R" flag next to retrograde planets
- surface retrograde information in the web page
- update README to mention retrogrades
- test retrograde output

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684503890fd8832e867f15dbed7c4c0b