### PR TITLE
Add body info helper and retrograde check

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,8 +86,8 @@ def compute_chart_points(jd, lat, lon, hsys=b'P'):
         'cusps': list(cusps),
     }
 
-def compute_positions(jd):
-    """Return ecliptic longitudes of major bodies for given Julian day."""
+def compute_body_info(jd):
+    """Return longitude and speed for each major body for the given Julian day."""
     planets = {
         'Sun': swe.SUN,
         'Moon': swe.MOON,
@@ -101,11 +101,21 @@ def compute_positions(jd):
         'Pluto': swe.PLUTO,
         'Mean Node': swe.MEAN_NODE,
     }
-    positions = {}
+    info = {}
     for name, body in planets.items():
-        lon_lat_dist = swe.calc_ut(jd, body)[0]
-        positions[name] = lon_lat_dist[0]
-    return positions
+        vals = swe.calc_ut(jd, body)[0]
+        info[name] = (vals[0], vals[3])
+    return info
+
+def compute_positions(jd):
+    """Return ecliptic longitudes of major bodies for given Julian day."""
+    info = compute_body_info(jd)
+    return {name: vals[0] for name, vals in info.items()}
+
+def compute_retrogrades(jd):
+    """Return True for bodies that are retrograde on the given day."""
+    info = compute_body_info(jd)
+    return {name: vals[1] < 0 for name, vals in info.items()}
 
 
 def angular_distance(lon1, lon2):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,6 +11,7 @@ from app import (
     compute_house_positions,
     compute_aspects,
     chart_ruler,
+    compute_retrogrades,
 )
 
 
@@ -71,4 +72,14 @@ def test_aspects_and_chart_ruler():
     )
     chart_points = compute_chart_points(jd, 0, 0, b'P')
     assert chart_ruler(chart_points['asc']) == 'Mars'
+
+
+def test_compute_retrogrades():
+    jd_direct = swe.julday(2000, 1, 1, 12.0)
+    jd_retro = swe.julday(2020, 6, 20, 0.0)
+    retro_direct = compute_retrogrades(jd_direct)
+    retro_retro = compute_retrogrades(jd_retro)
+    assert not retro_direct['Mercury']
+    assert retro_retro['Mercury']
+
 


### PR DESCRIPTION
## Summary
- add `compute_body_info` returning longitude and speed for each body
- refactor `compute_positions` and implement new `compute_retrogrades` using the helper
- test retrograde detection

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845064d1888832eb5c267c8666c766f