### PR TITLE
Use env var for Flask secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ pip install -r requirements-dev.txt  # for running tests
 ```
 The `requirements.txt` file now includes `matplotlib` which is used to draw the chart wheel.
 
+The application uses Flask sessions and expects a secret key. Set the
+`SECRET_KEY` environment variable to override the default development key.
+
 ## Running
 
 Run the Flask app with:

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import io
 import base64
 import math
 import matplotlib.pyplot as plt
+import os
 
 ZODIAC_SIGNS = [
     'Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo',
@@ -171,7 +172,7 @@ def chart_ruler(asc_longitude):
     return SIGN_RULERS.get(sign)
 
 app = Flask(__name__)
-app.secret_key = 'development-secret-key'
+app.secret_key = os.environ.get("SECRET_KEY", "development-secret-key")
 
 @app.route('/', methods=['GET', 'POST'])
 def index():


### PR DESCRIPTION
## Summary
- use `os.environ.get("SECRET_KEY", "development-secret-key")` in `app.py`
- document `SECRET_KEY` variable in README

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845065491bc832ebb49f59b37b4f260