### PR TITLE
Handle OSM lookup failures

### DIFF
--- a/app.py
+++ b/app.py
@@ -187,12 +187,17 @@ def index():
 
             # Resolve coordinates from city name if provided
             if city and (not lat_str or not lon_str):
-                resp = requests.get(
-                    'https://nominatim.openstreetmap.org/search',
-                    params={'q': city, 'format': 'json', 'limit': 1},
-                    headers={'User-Agent': 'moonandsun'}
-                )
-                resp.raise_for_status()
+                try:
+                    resp = requests.get(
+                        'https://nominatim.openstreetmap.org/search',
+                        params={'q': city, 'format': 'json', 'limit': 1},
+                        headers={'User-Agent': 'moonandsun'}
+                    )
+                    resp.raise_for_status()
+                except requests.RequestException:
+                    flash('City lookup failed')
+                    return render_template('index.html')
+
                 data = resp.json()
                 if not data:
                     raise ValueError('City not found')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import swisseph as swe
+import requests
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from app import (
@@ -71,4 +72,25 @@ def test_aspects_and_chart_ruler():
     )
     chart_points = compute_chart_points(jd, 0, 0, b'P')
     assert chart_ruler(chart_points['asc']) == 'Mars'
+
+
+def test_city_lookup_failure(monkeypatch):
+    client = app.test_client()
+    data = {
+        'date': '2000-01-01',
+        'time': '12:00',
+        'tz_offset': '0',
+        'city': 'Nowhere',
+        'latitude': '',
+        'longitude': '',
+        'house_system': 'P'
+    }
+
+    def mock_get(*args, **kwargs):
+        raise requests.RequestException()
+
+    monkeypatch.setattr('app.requests.get', mock_get)
+    resp = client.post('/', data=data)
+    assert resp.status_code == 200
+    assert b'City lookup failed' in resp.data
 


### PR DESCRIPTION
## Summary
- handle failures when looking up city coordinates via OSM
- test error handling on failed request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845065c88c4832ea2e6497b102fa476