### PR TITLE
Add additional chart points

### DIFF
--- a/templates/chart.html
+++ b/templates/chart.html
@@ -23,6 +23,8 @@
   <h2>Chart Points</h2>
   <p>Ascendant: {{ asc }}</p>
   <p>Midheaven: {{ mc }}</p>
+  <p>Vertex: {{ vertex }}</p>
+  <p>Part of Fortune: {{ part_of_fortune }}</p>
   <h2>Chart Ruler</h2>
   <p>{{ chart_ruler }}</p>
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -53,6 +53,13 @@ def test_index_post_positions():
     assert asc_str in resp.data
     assert cusp1 in resp.data
 
+    assert 'Chiron' in expected
+    assert 'Black Moon Lilith' in expected
+    vertex_str = format_longitude(chart_points['vertex']).replace("'", "&#39;").encode()
+    pof_str = format_longitude(chart_points['part_of_fortune']).replace("'", "&#39;").encode()
+    assert vertex_str in resp.data
+    assert pof_str in resp.data
+
     # Check whole sign houses differ
     data['house_system'] = 'W'
     resp2 = client.post('/', data=data)


### PR DESCRIPTION
## Summary
- compute Vertex and Part of Fortune in `compute_chart_points`
- pull Chiron data from JPL Horizons when Swiss Ephemeris lacks it
- add Black Moon Lilith and Chiron to computed bodies
- show Vertex and Part of Fortune in chart results
- test that new points appear in results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684576b5852c832e92444f47829f7468