### PR TITLE
Add timeout to geocoding request

### DIFF
--- a/app.py
+++ b/app.py
@@ -347,7 +347,8 @@ def index():
                     resp = requests.get(
                         'https://nominatim.openstreetmap.org/search',
                         params={'q': city, 'format': 'json', 'limit': 1},
-                        headers={'User-Agent': 'moonandsun'}
+                        headers={'User-Agent': 'moonandsun'},
+                        timeout=10
                     )
                     resp.raise_for_status()
                     data = resp.json()


### PR DESCRIPTION
## Summary
- use a 10 second timeout when looking up coordinates for a city

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68458160af0c832e862f2dfdf241ec22