### PR TITLE
Improve aspect presentation

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,16 +55,61 @@ SIGN_RULERS = {
 
 # Aspect configuration: aspect angle and maximum orb
 ASPECTS_INFO = {
-    'Conjunction': {'angle': 0, 'orb': 8},
-    'Opposition': {'angle': 180, 'orb': 8},
-    'Square': {'angle': 90, 'orb': 6},
-    'Trine': {'angle': 120, 'orb': 6},
-    'Sextile': {'angle': 60, 'orb': 4},
+    'Conjunction': {
+        'angle': 0,
+        'orb': 8,
+        'type': 'major',
+        'keywords': 'blending, emphasis',
+    },
+    'Opposition': {
+        'angle': 180,
+        'orb': 8,
+        'type': 'major',
+        'keywords': 'tension, awareness',
+    },
+    'Square': {
+        'angle': 90,
+        'orb': 6,
+        'type': 'major',
+        'keywords': 'challenge, action',
+    },
+    'Trine': {
+        'angle': 120,
+        'orb': 6,
+        'type': 'major',
+        'keywords': 'harmony, ease',
+    },
+    'Sextile': {
+        'angle': 60,
+        'orb': 4,
+        'type': 'major',
+        'keywords': 'opportunity, cooperation',
+    },
     # Extended aspects
-    'Quincunx': {'angle': 150, 'orb': 3},
-    'Semi-sextile': {'angle': 30, 'orb': 2},
-    'Semi-square': {'angle': 45, 'orb': 2},
-    'Sesquiquadrate': {'angle': 135, 'orb': 2},
+    'Quincunx': {
+        'angle': 150,
+        'orb': 3,
+        'type': 'minor',
+        'keywords': 'adjustment, discomfort',
+    },
+    'Semi-sextile': {
+        'angle': 30,
+        'orb': 2,
+        'type': 'minor',
+        'keywords': 'mild growth, awareness',
+    },
+    'Semi-square': {
+        'angle': 45,
+        'orb': 2,
+        'type': 'minor',
+        'keywords': 'irritation, friction',
+    },
+    'Sesquiquadrate': {
+        'angle': 135,
+        'orb': 2,
+        'type': 'minor',
+        'keywords': 'pressure, imbalance',
+    },
 }
 
 
@@ -231,13 +276,22 @@ def compute_aspects(positions):
                 orb = abs(diff - info['angle'])
                 if orb <= info['orb']:
                     strength = max(0.0, 1 - orb / info['orb'])
+                    importance = ''
+                    if orb <= 0.5:
+                        importance = 'exact'
+                    elif orb <= 1.0:
+                        importance = 'close'
                     aspects.append({
                         'planet1': p1,
                         'planet2': p2,
                         'aspect': aspect,
                         'orb': orb,
                         'strength': strength,
+                        'type': info.get('type', 'minor'),
+                        'keywords': info.get('keywords', ''),
+                        'importance': importance,
                     })
+    aspects.sort(key=lambda a: a['strength'], reverse=True)
     return aspects
 
 
@@ -390,6 +444,8 @@ def index():
             chart_points = compute_chart_points(jd, lat, lon, hsys)
             houses = compute_house_positions(positions, chart_points['cusps'])
             aspects = compute_aspects(positions)
+            major_aspects = [a for a in aspects if a['type'] == 'major']
+            minor_aspects = [a for a in aspects if a['type'] == 'minor']
             ruler = chart_ruler(chart_points['asc'])
             chart_img = draw_chart_wheel(positions, chart_points['cusps'], aspects)
             formatted_positions = {n: format_longitude(p) for n, p in positions.items()}
@@ -402,6 +458,8 @@ def index():
                 'chart.html',
                 positions=formatted_positions,
                 houses=houses,
+                major_aspects=major_aspects,
+                minor_aspects=minor_aspects,
                 aspects=aspects,
                 chart_ruler=ruler,
                 chart_img=chart_img,

--- a/static/style.css
+++ b/static/style.css
@@ -26,3 +26,7 @@ input, select {
     border: 1px solid #999;
     padding: 4px 8px;
 }
+
+.important {
+    background-color: #fffae6;
+}

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -30,16 +30,32 @@
   <h2>Chart Ruler</h2>
   <p>{{ chart_ruler }}</p>
 
-  <h2>Aspects</h2>
-  <table border="1">
-    <tr><th>Planet 1</th><th>Planet 2</th><th>Aspect</th><th>Orb</th><th>Strength</th></tr>
-    {% for asp in aspects %}
-    <tr>
+  <h2>Major Aspects</h2>
+  <table border="1" class="table">
+    <tr><th>Planet 1</th><th>Planet 2</th><th>Aspect</th><th>Orb</th><th>Strength</th><th>Keywords</th></tr>
+    {% for asp in major_aspects %}
+    <tr class="{% if asp.importance %}important{% endif %}">
       <td>{{ asp.planet1 }}</td>
       <td>{{ asp.planet2 }}</td>
       <td>{{ asp.aspect }}</td>
       <td>{{ '%.2f' % asp.orb }}</td>
       <td>{{ '%.2f' % asp.strength }}</td>
+      <td>{{ asp.keywords }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+
+  <h2>Minor Aspects</h2>
+  <table border="1" class="table">
+    <tr><th>Planet 1</th><th>Planet 2</th><th>Aspect</th><th>Orb</th><th>Strength</th><th>Keywords</th></tr>
+    {% for asp in minor_aspects %}
+    <tr class="{% if asp.importance %}important{% endif %}">
+      <td>{{ asp.planet1 }}</td>
+      <td>{{ asp.planet2 }}</td>
+      <td>{{ asp.aspect }}</td>
+      <td>{{ '%.2f' % asp.orb }}</td>
+      <td>{{ '%.2f' % asp.strength }}</td>
+      <td>{{ asp.keywords }}</td>
     </tr>
     {% endfor %}
   </table>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -109,6 +109,16 @@ def test_extended_aspects():
     )
 
 
+def test_aspect_sorting_and_keywords():
+    jd = swe.julday(2000, 1, 1, 12.0)
+    positions = compute_positions(jd)
+    aspects = compute_aspects(positions)
+    assert len(aspects) >= 2
+    assert aspects[0]['strength'] >= aspects[1]['strength']
+    assert 'type' in aspects[0]
+    assert 'keywords' in aspects[0]
+
+
 def test_compute_retrogrades():
     jd_direct = swe.julday(2000, 1, 1, 12.0)
     jd_retro = swe.julday(2020, 6, 20, 0.0)


### PR DESCRIPTION
## Summary
- categorize aspects as major or minor and include keywords
- sort computed aspects by strength and flag close aspects
- group aspects in the results template and highlight important ones
- style highlight rows in CSS
- test aspect ordering and metadata

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684583a07c04832ebbd21a9d8284e99d