### PR TITLE
Implement chart management capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Run the automated tests with:
 pytest
 ```
 
+## Chart Management
+
+After generating a chart you can save it from the results page. Saved charts are
+listed on a dedicated page where each entry shows the chart name and birth date.
+You can download or delete individual charts. The stored metadata includes the
+birth details, coordinates and chosen house system so charts remain identifiable.
+Saved image filenames incorporate the chart name and birth timestamp instead of
+generic numbers.
+
 ## Packaging
 
 You can create standalone executables for Windows, macOS and Linux using [PyInstaller](https://www.pyinstaller.org/). The repository includes a `natal_chart.spec` file that bundles the templates and license.

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -12,6 +12,10 @@
   <button id="download-btn" type="button">Download PNG</button>
   <form action="{{ url_for('save_chart') }}" method="post" style="margin-top:10px;">
     <input type="hidden" name="chart_img" value="{{ chart_img }}">
+    <input type="hidden" name="birth_dt" value="{{ dt.isoformat() }}">
+    <input type="hidden" name="house_system" value="{{ house_system }}">
+    <input type="hidden" name="latitude" value="{{ lat }}">
+    <input type="hidden" name="longitude" value="{{ lon }}">
     <label>Name this chart:</label>
     <input type="text" name="chart_name">
     <button type="submit">Save</button>

--- a/templates/charts.html
+++ b/templates/charts.html
@@ -10,7 +10,14 @@
   <ul>
   {% for c in charts %}
     <li>
-      {{ c.name }} - <a href="{{ url_for('download_chart', filename=c.file) }}">Download</a>
+      {{ c.name }}
+      {% if c.metadata %}
+        ({{ c.metadata.birth_dt }})
+      {% endif %}
+      - <a href="{{ url_for('download_chart', filename=c.file) }}">Download</a>
+      <form action="{{ url_for('delete_chart', filename=c.file) }}" method="post" style="display:inline;">
+        <button type="submit">Delete</button>
+      </form>
     </li>
   {% else %}
     <li>No charts saved.</li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,5 +46,6 @@
       document.body.classList.add('show-loading');
     });
   </script>
+  <p><a href="{{ url_for('list_charts') }}">View saved charts</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow saving extra chart metadata and better filenames
- enable deleting saved charts
- link to saved charts from the home page
- document new chart management features

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68458d8e3ab0832e89700efb6ee9785e