### PR TITLE
Address user experience gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 pip install -r requirements-dev.txt  # for running tests
 ```
-The `requirements.txt` file now includes `matplotlib` which is used to draw the chart wheel.
+The `requirements.txt` file now includes `matplotlib` which is used to draw the chart wheel. The Swiss Ephemeris Python bindings (`pyswisseph`) are an absolute requirement for running the application and executing the automated tests.
 
 The application uses Flask sessions and expects a secret key. Set the
 `SECRET_KEY` environment variable to override the default development key.

--- a/app.py
+++ b/app.py
@@ -550,8 +550,26 @@ def index():
             )
         except Exception as exc:
             flash(str(exc))
-            return render_template('index.html')
-    return render_template('index.html')
+            return render_template(
+                'index.html',
+                date_value=request.form.get('date', ''),
+                time_value=request.form.get('time', ''),
+                tz_offset_value=request.form.get('tz_offset', ''),
+                city_value=request.form.get('city', ''),
+                lat_value=request.form.get('latitude', ''),
+                lon_value=request.form.get('longitude', ''),
+                house_system_value=request.form.get('house_system', 'P'),
+            )
+    return render_template(
+        'index.html',
+        date_value='',
+        time_value='',
+        tz_offset_value='',
+        city_value='',
+        lat_value='',
+        lon_value='',
+        house_system_value='P',
+    )
 
 
 @app.route('/save_chart', methods=['POST'])
@@ -626,6 +644,36 @@ def delete_chart(filename):
     save_charts(charts)
     flash('Chart deleted')
     return redirect(url_for('list_charts'))
+
+
+@app.route('/edit/<path:filename>')
+def edit_chart(filename):
+    charts = load_charts()
+    chart = next((c for c in charts if c.get('file') == filename), None)
+    if not chart:
+        flash('Chart not found')
+        return redirect(url_for('list_charts'))
+    md = chart.get('metadata', {})
+    date_val = ''
+    time_val = ''
+    dt_iso = md.get('birth_dt')
+    if dt_iso:
+        try:
+            dt_obj = datetime.datetime.fromisoformat(dt_iso)
+            date_val = dt_obj.strftime('%Y-%m-%d')
+            time_val = dt_obj.strftime('%H:%M')
+        except ValueError:
+            pass
+    return render_template(
+        'index.html',
+        date_value=date_val,
+        time_value=time_val,
+        tz_offset_value='',
+        city_value='',
+        lat_value=md.get('latitude', ''),
+        lon_value=md.get('longitude', ''),
+        house_system_value=md.get('house_system', 'P'),
+    )
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -22,11 +22,12 @@
   </form>
   <script>
     document.getElementById('download-btn').addEventListener('click', function(){
-      const link = document.createElement('a');
-      link.href = 'data:image/png;base64,{{ chart_img }}';
-      link.download = 'chart.png';
-      link.click();
-    });
+        const link = document.createElement('a');
+        link.href = 'data:image/png;base64,{{ chart_img }}';
+        const dtStr = '{{ dt.strftime("%Y%m%d_%H%M") }}';
+        link.download = `chart_${dtStr}.png`;
+        link.click();
+      });
   </script>
   <p>Birth time (local): {{ dt }}</p>
   <p>Converted to UTC: {{ dt_utc }}</p>

--- a/templates/charts.html
+++ b/templates/charts.html
@@ -15,6 +15,7 @@
         ({{ c.metadata.birth_dt }})
       {% endif %}
       - <a href="{{ url_for('download_chart', filename=c.file) }}">Download</a>
+      | <a href="{{ url_for('edit_chart', filename=c.file) }}">Edit</a>
       <form action="{{ url_for('delete_chart', filename=c.file) }}" method="post" style="display:inline;">
         <button type="submit">Delete</button>
       </form>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,21 +20,21 @@
   {% endwith %}
   <form method="post">
     <label>Date of birth:</label>
-    <input type="date" name="date" required><br>
+    <input type="date" name="date" required value="{{ date_value|default('') }}"><br>
     <label>Time of birth:</label>
-    <input type="time" name="time" required><br>
+    <input type="time" name="time" required value="{{ time_value|default('') }}"><br>
     <label>City (optional):</label>
-    <input type="text" name="city"><br>
+    <input type="text" name="city" value="{{ city_value|default('') }}"><br>
     <label>Timezone offset from UTC (e.g., -5 for EST, leave blank for auto):</label>
-    <input type="number" name="tz_offset" step="any"><br>
+    <input type="number" name="tz_offset" step="any" value="{{ tz_offset_value|default('') }}"><br>
     <label>Latitude:</label>
-    <input type="number" name="latitude" step="any"><br>
+    <input type="number" name="latitude" step="any" value="{{ lat_value|default('') }}"><br>
     <label>Longitude:</label>
-    <input type="number" name="longitude" step="any"><br>
+    <input type="number" name="longitude" step="any" value="{{ lon_value|default('') }}"><br>
     <label>House system:</label>
     <select name="house_system">
-      <option value="P">Placidus</option>
-      <option value="W">Whole Sign</option>
+      <option value="P" {% if house_system_value == 'P' %}selected{% endif %}>Placidus</option>
+      <option value="W" {% if house_system_value == 'W' %}selected{% endif %}>Whole Sign</option>
     </select><br>
     <button type="submit">Generate</button>
   </form>
@@ -42,8 +42,10 @@
   <script>
     const form = document.querySelector('form');
     const loading = document.getElementById('loading');
-    form.addEventListener('submit', () => {
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
       document.body.classList.add('show-loading');
+      setTimeout(() => form.submit(), 0);
     });
   </script>
   <p><a href="{{ url_for('list_charts') }}">View saved charts</a></p>


### PR DESCRIPTION
## Summary
- allow modifying saved charts by adding `/edit` route
- preload form fields when editing a chart
- fix download filename to include birth datetime
- show loading indicator before form submission
- note that `pyswisseph` is required for running and testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458ed75b20832e8bdb3a721414dec0