### PR TITLE
Improve date validation and city lookup robustness

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -182,3 +182,18 @@ def test_filter_aspects_for_wheel():
         )
 
 
+def test_birth_date_validation():
+    client = app.test_client()
+    data = {
+        'date': '1700-01-01',
+        'time': '12:00',
+        'tz_offset': '0',
+        'latitude': '0',
+        'longitude': '0',
+        'house_system': 'P'
+    }
+    resp = client.post('/', data=data)
+    assert resp.status_code == 200
+    assert b'Date must be between' in resp.data
+
+


### PR DESCRIPTION
## Summary
- validate input birth dates to be between 1800 and 2100
- allow longer timeout for city lookups
- test date validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684591e597ec832e9ca63a740f9b4b91