### PR TITLE
Implement extra Arabic parts and node options

### DIFF
--- a/templates/chart.html
+++ b/templates/chart.html
@@ -14,6 +14,7 @@
     <input type="hidden" name="chart_img" value="{{ chart_img }}">
     <input type="hidden" name="birth_dt" value="{{ dt.isoformat() }}">
     <input type="hidden" name="house_system" value="{{ house_system }}">
+    <input type="hidden" name="node_type" value="{{ node_type }}">
     <input type="hidden" name="latitude" value="{{ lat }}">
     <input type="hidden" name="longitude" value="{{ lon }}">
     <label>Name this chart:</label>
@@ -61,6 +62,10 @@
   <p>Midheaven: {{ mc }}</p>
   <p>Vertex: {{ vertex }}</p>
   <p>Part of Fortune: {{ part_of_fortune }}</p>
+  <p>Part of Spirit: {{ part_of_spirit }}</p>
+  <p>Part of Love: {{ part_of_love }}</p>
+  <p>Part of Marriage: {{ part_of_marriage }}</p>
+  <p>Part of Death: {{ part_of_death }}</p>
   <h2>Chart Ruler</h2>
   <p>{{ chart_ruler }}</p>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,6 +37,11 @@
       <option value="{{ code }}" {% if house_system_value == code %}selected{% endif %}>{{ name }}</option>
       {% endfor %}
     </select><br>
+    <label>Lunar node:</label>
+    <select name="node_type">
+      <option value="mean" {% if node_type == 'mean' %}selected{% endif %}>Mean Node</option>
+      <option value="true" {% if node_type == 'true' %}selected{% endif %}>True Node</option>
+    </select><br>
     <button type="submit">Generate</button>
   </form>
   <div id="loading">Loading...</div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -246,3 +246,22 @@ def test_yod_and_stellium_detection():
     assert ('Jupiter', 'Mars', 'Mercury') in patterns['yods']
 
 
+def test_big_four_asteroids_and_parts():
+    jd = swe.julday(2000, 1, 1, 12.0)
+    positions = compute_positions(jd)
+    for name in ['Ceres', 'Pallas', 'Juno', 'Vesta']:
+        assert name in positions
+    points = compute_chart_points(jd, 0, 0, b'P')
+    for key in ['part_of_spirit', 'part_of_love', 'part_of_marriage', 'part_of_death']:
+        assert key in points
+
+
+def test_true_node_option():
+    jd = swe.julday(2000, 1, 1, 12.0)
+    mean_pos = compute_positions(jd, 'mean')
+    true_pos = compute_positions(jd, 'true')
+    assert 'Mean Node' in mean_pos
+    assert 'True Node' in true_pos
+    assert mean_pos['Mean Node'] != true_pos['True Node']
+
+


### PR DESCRIPTION
## Summary
- compute additional Arabic parts including Part of Spirit
- support True vs Mean lunar node and add Big Four asteroids
- expose node type option in UI and save it with charts
- update templates to show new chart points
- cover new functionality with tests

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459ae58a04832ea5498ff4c90dde34