### PR TITLE
Add chart wheel interactivity and theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The application uses Flask sessions and expects a secret key. Set the
 `SECRET_KEY` environment variable to override the default development key.
 Chart wheel size can be customised by setting `CHART_FIGSIZE` to a comma
 separated width and height (e.g. `7,7`).
+The `CHART_THEME` variable toggles between light and dark colors, and
+`CHART_INTERACTIVE=1` enables an interactive wheel with tooltips.
 
 ## Running
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyswisseph
 requests
 timezonefinder
 matplotlib
+mpld3

--- a/static/style.css
+++ b/static/style.css
@@ -31,6 +31,15 @@ input, select {
     background-color: #fffae6;
 }
 
+.chart-img {
+    opacity: 0;
+    animation: fadeIn 1s forwards;
+}
+
+@keyframes fadeIn {
+    to { opacity: 1; }
+}
+
 #loading {
     display: none;
     margin-top: 10px;

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -8,7 +8,11 @@
 </head>
 <body>
   <h1>Natal Chart</h1>
-  <img src="data:image/png;base64,{{ chart_img }}" alt="Chart Wheel">
+  {% if interactive %}
+  <div id="chart-container">{{ chart_html|safe }}</div>
+  {% else %}
+  <img class="chart-img" src="data:image/png;base64,{{ chart_img }}" alt="Chart Wheel">
+  {% endif %}
   <button id="download-btn" type="button">Download PNG</button>
   <form action="{{ url_for('save_chart') }}" method="post" style="margin-top:10px;">
     <input type="hidden" name="chart_img" value="{{ chart_img }}">


### PR DESCRIPTION
## Summary
- allow light/dark theme via `CHART_THEME`
- add interactive chart option with tooltips and zoom
- vary aspect line width by orb strength
- highlight angular house boundaries
- animate wheel image fade-in
- document new environment variables

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459e403884832e8623eea054ec3c04