### PR TITLE
Add NSIS installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ pyinstaller natal_chart.spec
 
 The resulting executable will be placed in the `dist/` directory. If you added `icons/icon.ico` before building on Windows (or `icon.icns` on macOS) the installer will include it automatically.
 
+### Windows installer
+
+To build a traditional Windows installer install [NSIS](https://nsis.sourceforge.io/)
+and run:
+
+```bash
+makensis installer.nsi
+```
+
+This produces `moonandsun_setup.exe` that installs the packaged application to
+`Program Files/MoonAndSun` with desktop and Start Menu shortcuts.
+
 ## Time-Based Features
 
 Additional helpers calculate progressed and return charts:

--- a/installer.nsi
+++ b/installer.nsi
@@ -1,0 +1,20 @@
+; NSIS installer script for Moon and Sun Natal Chart
+; Build with: makensis installer.nsi
+
+!include "MUI2.nsh"
+
+Name "Moon and Sun Natal Chart"
+OutFile "moonandsun_setup.exe"
+InstallDir "$PROGRAMFILES\MoonAndSun"
+RequestExecutionLevel admin
+
+Page directory
+Page instfiles
+
+Section "Install"
+    SetOutPath "$INSTDIR"
+    File /r "dist\natal_chart\*.*"
+    CreateShortcut "$DESKTOP\Moon and Sun.lnk" "$INSTDIR\natal_chart.exe"
+    CreateDirectory "$SMPROGRAMS\Moon and Sun"
+    CreateShortcut "$SMPROGRAMS\Moon and Sun\Moon and Sun.lnk" "$INSTDIR\natal_chart.exe"
+SectionEnd


### PR DESCRIPTION
## Summary
- provide `installer.nsi` for building a Windows installer
- document NSIS usage in the Packaging section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d2dbee6c832eb7bae1d1c669dc99